### PR TITLE
fix(ci): split chart-lint-test into chart-lint-helm and chart-e2e

### DIFF
--- a/.github/workflows/chart-lint-test.yml
+++ b/.github/workflows/chart-lint-test.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: deploy/helm
         run: ah lint
 
-  lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -62,8 +62,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.x'
           check-latest: true
@@ -87,48 +86,38 @@ jobs:
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.list-changed.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.list-changed.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/hive-operator:$VERSION
-
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/hive-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-          )
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
-
-          # Install packaged operator chart
-          helm install --create-namespace --namespace hive-operators --wait hive-operator ./target/charts/hive-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,7 +179,7 @@ jobs:
         run: ah lint
 
 
-  chart-lint-test:
+  chart-lint-helm:
     runs-on: ubuntu-latest
     needs:
       - check-crds-sync
@@ -209,8 +209,16 @@ jobs:
         id: commit-range
         run: |
           # Get current and previous tag
+          # Exclude -dev pre-release tags only when looking for the previous tag,
+          # not when matching the current tag itself
           CURRENT_TAG="${{ github.ref_name }}"
-          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -A1 "^${CURRENT_TAG}$" | tail -n1 | grep -v '\-dev$')
+
+          # If the -dev tag itself was the only match (no previous stable tag found),
+          # try again excluding -dev to find the actual previous stable release
+          if [[ -z "$PREVIOUS_TAG" ]]; then
+            PREVIOUS_TAG=$(git tag --sort=-v:refname | grep -v '\-dev$' | grep -A1 "^${CURRENT_TAG}$" | tail -n1)
+          fi
 
           # First release detection
           if [[ "$PREVIOUS_TAG" == "$CURRENT_TAG" || -z "$PREVIOUS_TAG" ]]; then
@@ -282,53 +290,45 @@ jobs:
       - name: Create kind cluster
         if: steps.check-changes.outputs.changed == 'true'
         uses: helm/kind-action@v1.14.0
+
+      - name: Setup Go
+        if: steps.check-changes.outputs.changed == 'true'
+        uses: actions/setup-go@v6
         with:
-          cluster_name: kind  # Default cluster name is 'chart-testing'
+          go-version-file: go.mod
+
+      - name: Build image
+        if: steps.check-changes.outputs.changed == 'true'
+        run: make docker-build
 
       - name: Load images to cluster
         if: steps.check-changes.outputs.changed == 'true'
-        run: |
-          make docker-build
-          kind load docker-image quay.io/zncdatadev/hive-operator:$VERSION
+        run: kind load docker-image --name chart-testing quay.io/zncdatadev/hive-operator:$VERSION
 
       - name: Run chart-testing (install)
-        id: ct-test
         if: steps.check-changes.outputs.changed == 'true'
         run: |
           ct install \
             --since "${{ steps.commit-range.outputs.since_commit }}" \
             --target-branch "${{ steps.commit-range.outputs.target_branch }}" \
             --config ./.github/configs/ct-install.yaml
-          # Save success result to github output
-          if [[ $? -eq 0 ]]; then
-            echo "ct_tested=true" >> "$GITHUB_OUTPUT"
-          fi
 
-      - name: Build helm chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          make helm-chart-package
 
-      - name: Run e2e with chart
-        if: steps.ct-test.outputs.ct_tested == 'true'
-        run: |
-          HELM_DEPENDENCIES=(
-            commons-operator
-            listener-operator
-            secret-operator
-          )
+  chart-e2e:
+    runs-on: ubuntu-latest
+    needs:
+      - check-crds-sync
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@v6
 
-          # Install dependencies
-          for dep in "${HELM_DEPENDENCIES[@]}"; do
-            helm upgrade --install --create-namespace --namespace kubedoop-operators --wait $dep oci://quay.io/kubedoopcharts/$dep --version $VERSION
-          done
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
-          # Install packaged operator chart
-          helm install --create-namespace --namespace hive-operators --wait hive-operator ./target/charts/hive-operator-$VERSION.tgz
-
-          # E2E tests
-          make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+      - name: Run chart-e2e
+        run: make chart-e2e
 
 
   release-chart:
@@ -337,7 +337,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - chart-linter-artifacthub
-      - chart-lint-test
+      - chart-lint-helm
+      - chart-e2e
     steps:
       - name: Clone the code
         uses: actions/checkout@v6
@@ -394,6 +395,12 @@ jobs:
           if [ -z "$CHART_NAME" ] || [ -z "$CHART_VERSION" ]; then
             echo "Failed to extract CHART_NAME or CHART_VERSION from package filename: $CHART_PACKAGE"
             exit 1
+          fi
+
+          # Skip -dev pre-release tags from index
+          if echo "$CHART_VERSION" | grep -q '\-dev$'; then
+            echo "Skipping -dev pre-release tag: $CHART_VERSION"
+            exit 0
           fi
 
           # Regenerate the index.yaml file for the helm charts repository

--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,14 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
+.PHONY: chart-e2e
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
+	"$(HELM)" upgrade --install --create-namespace --namespace $(PROJECT_NAME) \
+		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
+		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+
 .PHONY: chainsaw-e2e
 chainsaw-e2e: ## Run the chainsaw e2e tests
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,187 @@
+# Release Guide
+
+This document describes the standard release process for hive-operator.
+
+## Overview
+
+The release process follows a branch-based workflow:
+
+- **Main branch** (`main`): The default development branch where new features and bug fixes are merged.
+- **Release branch** (`release-x.y`): A long-lived branch for a minor version series
+  (e.g., `release-0.4`). Created from `main`, only accepts bug fixes and
+  dependency upgrades, no new features. All release tags are created from this
+  branch to ensure published code is stable and verified.
+
+## How Versioning Works
+
+The release workflow does **not** require manual version changes in source
+files. The Git tag name serves as the single source of truth for the version
+number:
+
+1. When a tag (e.g., `0.4.0`) is pushed, the
+   [Release workflow](../.github/workflows/release.yml) sets `VERSION` from
+   `github.ref_name`
+2. **Docker image** — uses `VERSION` directly:
+   `quay.io/zncdatadev/hive-operator:<version>`
+3. **Helm chart** — `helm package --version $(VERSION) --app-version $(VERSION)`
+   overrides the values in `Chart.yaml` during packaging
+4. **Helm chart publish** — pushes to
+   `quay.io/kubedoopcharts/hive-operator:<version>` (OCI registry)
+
+The `VERSION` in `Makefile` and `version`/`appVersion` in `Chart.yaml` are
+development-time defaults (`0.0.0-dev`) on `main`. They do not need to be
+updated for a release.
+
+## Release Process
+
+### 1. Prepare Content
+
+Prepare the code to be released before creating the release branch. This
+includes merging bug fixes, dependency upgrades, or other stabilization changes
+into `main` via Pull Request. Wait for CI to pass and code review before
+proceeding.
+
+### 2. Create Release Branch
+
+Create a release branch on the upstream repository from the prepared `main`.
+
+**Via GitHub WebUI:** Navigate to the repository page, click "Branch" →
+"New branch", name it `release-0.x` and base it on `main`.
+
+**Via GitHub API / gh CLI:**
+
+```bash
+gh api repos/zncdatadev/hive-operator/git/refs \
+  -f ref=refs/heads/release-0.x \
+  -f sha=$(gh api repos/zncdatadev/hive-operator/git/ref/heads/main --jq .object.sha)
+```
+
+Then sync locally:
+
+```bash
+git fetch upstream
+git checkout release-0.x
+```
+
+### 3. Pre-release Verification
+
+Push a `-dev` suffixed tag on the release branch to verify the release
+workflow. This confirms the code can be released correctly.
+
+```bash
+git pull --rebase upstream release-0.x
+git tag x.y.z-dev upstream/release-0.x
+git push upstream x.y.z-dev
+```
+
+Wait for the release workflow to complete. Verify:
+
+- All jobs pass successfully
+- Docker image is available at
+  `quay.io/zncdatadev/hive-operator:x.y.z-dev`
+- Helm chart is available at
+  `quay.io/kubedoopcharts/hive-operator:x.y.z-dev`
+
+If the workflow fails, fix the issue, then delete and re-create the `-dev`
+tag:
+
+```bash
+git tag -d x.y.z-dev
+git push upstream :refs/tags/x.y.z-dev
+git tag x.y.z-dev upstream/release-0.x
+git push upstream x.y.z-dev
+```
+
+Once verified, you can proceed to publish the stable version directly.
+There is no need to clean up the `-dev` tag.
+
+### 4. Tag and Publish
+
+```bash
+git pull --rebase upstream release-0.x
+git tag x.y.z upstream/release-0.x
+git push upstream x.y.z
+```
+
+This triggers the [Release workflow](../.github/workflows/release.yml) which
+runs the following jobs:
+
+- **Markdown Lint** — Lints markdown files under `docs/` and `README.*.md`
+- **Golang Lint** — Runs golangci-lint
+- **Golang Test** — Runs unit tests
+- **Chainsaw Test** — Runs Chainsaw E2E tests across multiple Kubernetes versions and product versions
+- **CRD Sync Check** — Verifies CRDs are in sync with manifests
+- **Chart Linter (Artifact Hub)** — Validates Helm chart metadata
+- **Chart Lint Helm** — Validates the Helm chart with `ct lint` and installs it with `ct install`
+- **Chart E2E** — Runs Chainsaw E2E tests against a Helm-installed release
+- **Release Image** — Builds and pushes multi-arch Docker image using the root
+  Dockerfile to `quay.io/zncdatadev/hive-operator:<version>`, and signs the
+  image with Cosign
+- **Release Chart** — Publishes the Helm chart to
+  `quay.io/kubedoopcharts/hive-operator:<version>` (OCI registry) and
+  updates the [kubedoop-helm-charts](https://github.com/zncdatadev/kubedoop-helm-charts)
+  index
+
+## Versioning Convention
+
+hive-operator follows [Semantic Versioning](https://semver.org/):
+
+- **Patch** (x.y.Z): Bug fixes, no API changes
+- **Minor** (x.Y.z): New features, backward-compatible API changes
+- **Major** (X.y.z): Breaking API changes
+
+## Example
+
+Here is an example of releasing version `0.4.0` on the `release-0.4` branch:
+
+```bash
+# Step 1: Prepare content on main
+# Merge stabilization changes via PR, wait for CI and review
+
+# Step 2: Create release branch on upstream
+# Via WebUI or:
+gh api repos/zncdatadev/hive-operator/git/refs \
+  -f ref=refs/heads/release-0.4 \
+  -f sha=$(gh api repos/zncdatadev/hive-operator/git/ref/heads/main --jq .object.sha)
+
+# Sync locally
+git fetch upstream
+git checkout release-0.4
+
+# Step 3: Pre-release verification
+git pull --rebase upstream release-0.4
+git tag 0.4.0-dev upstream/release-0.4
+git push upstream 0.4.0-dev
+# Wait for workflow to pass
+
+# Step 4: Tag and publish (stable version, can only be published once)
+git pull --rebase upstream release-0.4
+git tag 0.4.0 upstream/release-0.4
+git push upstream 0.4.0
+```
+
+## Troubleshooting
+
+### Chart release failed
+
+If the `chart-lint-helm` or `release-chart` job fails, check the workflow logs
+for details. Common issues include:
+
+- **CRDs out of sync**: Run `make manifests` and `make helm-crd-sync` to
+  regenerate CRDs, then commit the changes.
+- **Previous tag not found**: For the first release on a new release branch, the
+  workflow automatically detects this and marks all charts as changed.
+
+### Re-trigger a pre-release
+
+Only `-dev` pre-release tags can be deleted and re-pushed. To re-trigger:
+
+```bash
+git tag -d x.y.z-dev
+git push upstream :refs/tags/x.y.z-dev
+git tag x.y.z-dev upstream/release-0.x
+git push upstream x.y.z-dev
+```
+
+**Stable versions (`x.y.z` without suffix) cannot be re-tagged.** If a stable
+release fails, you must publish a new patch version (e.g., `x.y.(z+1)`) instead.


### PR DESCRIPTION
## Summary

Split the monolithic `chart-lint-test` job into two independent jobs:
- **`chart-lint-helm`**: Helm lint + `ct install` (chart installation testing)
- **`chart-e2e`**: Full e2e tests with Helm chart deployment via `make chart-e2e`

## Changes

### `.github/workflows/chart-lint-test.yml`
- Renamed `lint-test` job to `chart-lint-helm`
- Added independent `Setup Go` step (using `actions/setup-go@v6` with `go-version-file: go.mod`)
- Added independent `Build image` step (using `make docker-build`)
- Removed `cluster_name: kind` from `helm/kind-action`
- Added `--name chart-testing` to `kind load docker-image`
- Removed `id: ct-test` and conditional tracking logic from `ct install`
- Removed inline "Build helm chart" and "Run e2e with chart" steps
- Added independent `chart-e2e` job (Checkout → Setup Go → `make chart-e2e`)

### `.github/workflows/release.yml`
- Renamed `chart-lint-test` job to `chart-lint-helm` with all the same changes as above
- Added `-dev` tag filtering in `Get commit range` step (skip `-dev` pre-release tags when finding previous tag)
- Removed inline "Build helm chart" and "Run e2e with chart" steps
- Added independent `chart-e2e` job (needs: `[check-crds-sync]`)
- Updated `release-chart.needs` to `[chart-linter-artifacthub, chart-lint-helm, chart-e2e]`
- Added `-dev` tag skip logic in Release Helm Chart step

### `Makefile`
- Added `chart-e2e` target: sets up Kind cluster, builds Docker image, packages Helm chart, loads image, installs chart via Helm, then runs chainsaw e2e tests

## Reference

Aligned with the zookeeper-operator workflow pattern.