### PR TITLE
chore: bump Go to 1.25.8 and update Dockerfile base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM quay.io/zncdatadev/go-devel:1.25.5-kubedoop0.0.0-dev AS builder
+FROM quay.io/zncdatadev/go-devel:1.25.8-kubedoop0.0.0-dev AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG LDFLAGS

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zncdatadev/hive-operator
 
-go 1.25.5
+go 1.25.8
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1


### PR DESCRIPTION
Bump Go from 1.25.5 to 1.25.8 and update Dockerfile base image accordingly.