### PR TITLE
fix: use CR spec productVersion in GetImage() and update default to 4.0.1

### DIFF
--- a/api/v1alpha1/image.go
+++ b/api/v1alpha1/image.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	DefaultRepository     = "quay.io/zncdatadev"
-	DefaultProductVersion = "3.1.3"
+	DefaultProductVersion = "4.0.1"
 	DefaultProductName    = "hive"
 )
 

--- a/internal/controller/cluster.go
+++ b/internal/controller/cluster.go
@@ -35,10 +35,15 @@ func NewClusterReconciler(
 }
 
 func (r *ClusterReconciler) GetImage() *util.Image {
+	productVersion := r.Spec.Image.ProductVersion
+	if productVersion == "" {
+		productVersion = hivev1alpha1.DefaultProductVersion
+	}
+
 	image := util.NewImage(
 		hivev1alpha1.DefaultProductName,
 		version.BuildVersion,
-		hivev1alpha1.DefaultProductVersion,
+		productVersion,
 		func(options *util.ImageOptions) {
 			options.Custom = r.Spec.Image.Custom
 			options.Repo = r.Spec.Image.Repo


### PR DESCRIPTION
Same issue as zookeeper-operator #348 and hdfs-operator #311. GetImage() was hardcoded to use DefaultProductVersion (3.1.3), ignoring the productVersion field set in the HiveCluster CR spec.

- Honor r.Spec.Image.ProductVersion when set, fallback to DefaultProductVersion
- Update DefaultProductVersion from 3.1.3 to 4.0.1 (latest stable, per zncdata-containers/hive/versions.yaml)