### PR TITLE
fix: add --config to chainsaw test in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,7 @@ jobs:
 
           # E2E tests
           make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 
   release-chart:


### PR DESCRIPTION
## Problem

The chart e2e step in `release.yml` was missing `--config`, causing chainsaw to use **default timeouts (AssertTimeout 30s)** instead of the configured values in `.chainsaw.yaml` (assert: 120s).

Heavy services like Hive Metastore need >30s to start (DB schema init + thrift server), causing **false timeout failures** in the Release workflow while the standalone Chainsaw Test jobs pass fine.

## Why Chainsaw Test jobs passed but chart e2e failed

| Job | Command | AssertTimeout | Result |
|-----|---------|--------------|--------|
| Chainsaw Test (6 matrix combos) | `make chainsaw-e2e` (uses `.chainsaw.yaml` via Makefile) | **120s** | ✅ All pass |
| chart e2e in Release | `./bin/chainsaw test --test-dir ./test/e2e/` (no `--config`) | **30s (default)** | ❌ Timeout |

## Fix

```diff
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
```

This aligns the release workflow with `chart-lint-test.yml` which already uses `--config`.

## Verified

- Confirmed Hive Metastore starts successfully in ~45-77s in local KinD cluster
- Confirmed `.chainsaw.yaml` sets `assert: 120s`, `error: 10s`
- Tested on KinD v1.34.3 cluster locally