### PR TITLE
ci: fix make target and chainsaw config in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,7 @@ jobs:
 
           # E2E tests
           make chainsaw
-          ./bin/chainsaw test --test-dir ./test/e2e/
+          ./bin/chainsaw test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
 
 
   release-chart:
@@ -351,7 +351,7 @@ jobs:
 
       - name: Build and push oci chart
         run: |
-          make chart-publish
+          make helm-chart-publish
 
       - name: Clone helm charts repository
         uses: actions/checkout@v6


### PR DESCRIPTION
## Changes

1. **Fix make target**: Release Chart job used `make chart-publish` but the actual Makefile target is `helm-chart-publish`, causing `make: *** No rule to make target 'chart-publish'` error.

2. **Add --config to chainsaw test**: The chainsaw test command in the release workflow was missing `--config ./test/e2e/.chainsaw.yaml`, causing it to use the default 30s timeout. Hive is a heavyweight application that requires more time, leading to false timeout failures.

## Verification

- [x] Makefile confirms target name is `helm-chart-publish`
- [x] `.chainsaw.yaml` exists at `test/e2e/.chainsaw.yaml`
- [x] `chart-lint-test.yml` already uses `--config` correctly (consistent)