### PR TITLE
fix: prevent S3 credential leak in container log, fix service scope rendering, bump kind default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ CHAINSAW_KUBECONFIG ?= .kubeconfig
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
 # and the target kubeconfig file will be named as `$(CHAINSAW_KUBECONFIG)` (default: `.kubeconfig`).
 # So if you want to use the target cluster, run `export KUBECONFIG=$(CHAINSAW_KUBECONFIG)` (default: `.kubeconfig`).
-KIND_K8S_VERSION ?= 1.26.15
+KIND_K8S_VERSION ?= 1.35.0
 # The kind node image can found in https://github.com/kubernetes-sigs/kind/releases.
 KIND_IMAGE ?= kindest/node:v${KIND_K8S_VERSION}
 # Define operator dependencies to be installed before running chainsaw tests.

--- a/internal/controller/s3.go
+++ b/internal/controller/s3.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path"
 	"strconv"
@@ -120,7 +121,11 @@ func (s *S3Config) GetVolumes() []corev1.Volume {
 		if credential.Scope.Pod {
 			scopes = append(scopes, string(constants.PodScope))
 		}
-		scopes = append(scopes, credential.Scope.Services...)
+		// The secret-operator scope parser only recognizes service entries in the
+		// form "service=<name>"; bare names are skipped with "Unknown scope".
+		for _, svc := range credential.Scope.Services {
+			scopes = append(scopes, fmt.Sprintf("%s=%s", constants.ServiceScope, svc))
+		}
 
 		annotations[constants.AnnotationSecretsScope] = strings.Join(scopes, constants.CommonDelimiter)
 	}

--- a/internal/controller/statefulset.go
+++ b/internal/controller/statefulset.go
@@ -135,7 +135,9 @@ func (b *StatefulSetBuilder) getMainContainer(krb5Config *KerberosConfig, s3Conf
 		b.RoleName,
 		b.GetImage(),
 	)
-	container.SetCommand([]string{"sh", "-x", "-euo", "pipefail", "-c"}).
+	// Do not use `-x` here: the script exports S3 credentials read from files,
+	// and xtrace would echo the expanded secret values into the container log.
+	container.SetCommand([]string{"sh", "-euo", "pipefail", "-c"}).
 		SetArgs(b.getMainContainerCommandArgs(krb5Config, s3Config)).
 		AddEnvVars(b.getMainContainerEnv(krb5Config)).
 		AddEnvFromSecret(b.ClusterConfig.Database.CredentialsSecret).


### PR DESCRIPTION
## Summary

Applies fixes discovered during the spark-k8s-operator refactor review (same issues landed in spark-k8s-operator `refactor/operator-go-next`).

- **Credential leak via shell xtrace** (`internal/controller/statefulset.go`): the metastore container command used `sh -x -euo pipefail -c`, while the startup script exports S3 credentials via `export AWS_ACCESS_KEY_ID=$(cat ...)`. With `-x`, the shell echoes the **expanded** credential values into the container log. Dropped `-x`, kept `-euo pipefail`.
- **S3 credential scope services rendered as bare names** (`internal/controller/s3.go`): the secret-operator CSI scope parser only understands `service=<name>` entries and skips bare names with "Unknown scope, skip it". Now rendered as `service=<name>`, matching the convention already used in `kerberos.go`. (Once the operator-go `security.ScopeString` / `pkg/s3` helpers ship, this can migrate to them.)
- **Stale kind default** (`Makefile`): `KIND_K8S_VERSION` defaulted to `1.26.15`. The operator-go framework injects Vector as a native sidecar (restartable init container), which requires Kubernetes >= 1.29; on a 1.26 cluster the API server drops `restartPolicy` and rejects pods with `spec.initContainers[0].readinessProbe: Forbidden`. Bumped the default to `1.35.0` to match the CI matrix.

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all unit/envtest suites pass
- [ ] Chainsaw e2e via CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)